### PR TITLE
Prepend zero-byte before unsigned integers

### DIFF
--- a/mib.c
+++ b/mib.c
@@ -372,7 +372,7 @@ static int data_alloc(data_t *data, int type)
 		case BER_TYPE_COUNTER:
 		case BER_TYPE_GAUGE:
 		case BER_TYPE_TIME_TICKS:
-			data->max_length = sizeof(unsigned int) + 2;
+			data->max_length = sizeof(unsigned int) + 3;
 			data->encoded_length = 0;
 			data->buffer = allocate(data->max_length);
 			break;

--- a/mib.c
+++ b/mib.c
@@ -207,6 +207,11 @@ static int encode_unsigned(data_t *data, int type, unsigned int ticks_value)
 	else
 		length = 1;
 
+	/* check if the integer could be interpreted negative during a signed decode and prepend a zero-byte if necessary */
+	if ((ticks_value >> (8 * (length - 1))) & 0x80) {
+		length++;
+	}
+
 	*buffer++ = type;
 	*buffer++ = length;
 	while (length--)


### PR DESCRIPTION
As written in #8, currently a unsigned value of `33000` will be encoded as `0x80e8`. As Counter32 (and other unsigned types) are treated as regular Integers in X.690 (and most implementations), they will assume a two's complement and decode `-32536`, resulting in utterly behavior.
This pull request resolves this by prepending a zero-byte if the first bit of the unsigned integer is a `1` and therefore could be seen as two's complement.