### PR TITLE
Provide real MAC addresses instead of dummy

### DIFF
--- a/freebsd.c
+++ b/freebsd.c
@@ -30,6 +30,7 @@
 #include <sys/statvfs.h>
 #include <sys/socket.h>
 #include <net/if.h>
+#include <net/if_dl.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <syslog.h>
@@ -216,6 +217,8 @@ void get_netinfo(netinfo_t *netinfo)
 		netinfo->tx_packets[i] = ifd->ifi_opackets;
 		netinfo->tx_errors[i]  = ifd->ifi_oerrors;
 		netinfo->tx_drops[i]   = ifd->ifi_collisions;
+
+		memcpy(&netinfo->mac_addr[i][0], LLADDR((struct sockaddr_dl *)ifa->ifa_addr), 6);
 	}
 
 	freeifaddrs(ifap);

--- a/linux.c
+++ b/linux.c
@@ -166,6 +166,10 @@ void get_netinfo(netinfo_t *netinfo)
 			netinfo->status[i] = (ifreq.ifr_flags & IFF_RUNNING) ? 1 : 7;
 		else
 			netinfo->status[i] = 2;
+
+		if (ioctl(fd, SIOCGIFHWADDR, &ifreq) == -1)
+			continue;
+		memcpy(&netinfo->mac_addr[i][0], &ifreq.ifr_hwaddr.sa_data[0], 6);
 	}
 	if (fd != -1)
 		close(fd);

--- a/mini_snmpd.h
+++ b/mini_snmpd.h
@@ -229,6 +229,7 @@ typedef struct netinfo_s {
 	unsigned int tx_packets[MAX_NR_INTERFACES];
 	unsigned int tx_errors[MAX_NR_INTERFACES];
 	unsigned int tx_drops[MAX_NR_INTERFACES];
+	char mac_addr[MAX_NR_INTERFACES][6];
 } netinfo_t;
 
 #ifdef CONFIG_ENABLE_DEMO


### PR DESCRIPTION
Introduce the infrastructure for updating arbitrary binary data (not
only NULL-terminated strings) and use it to update MAC address in
IF-MIB::ifPhysAddress periodically.
We take into account the fact that many NICs allow changing the MAC
freely in run time.

This change was tested successfully on Linux, but only built (without real test) on freebsd.