### PR TITLE
fix unknown type name 'sa_family_t' error

### DIFF
--- a/linux.c
+++ b/linux.c
@@ -15,9 +15,9 @@
 #ifdef __linux__
 
 #include <netpacket/packet.h>
-#include <linux/if_link.h>
 #include <sys/sysinfo.h>
 #include <sys/socket.h>
+#include <linux/if_link.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/time.h>


### PR DESCRIPTION
fix compile error unknown type name 'sa_family_t' on old kernels.

ref: https://bugs.freedesktop.org/show_bug.cgi?id=67075