### PR TITLE
Use consistent timeout setting between command line and config file

### DIFF
--- a/globals.c
+++ b/globals.c
@@ -25,7 +25,7 @@
 const struct in_addr inaddr_any = { INADDR_ANY };
 
 int       g_family  = AF_INET;
-int       g_timeout = 100;
+int       g_timeout = 1;
 int       g_auth    = 0;
 int       g_daemon  = 1;
 int       g_syslog  = 0;

--- a/mini-snmpd.c
+++ b/mini-snmpd.c
@@ -476,7 +476,7 @@ int main(int argc, char *argv[])
 			break;
 
 		case 't':
-			g_timeout = atoi(optarg) * 100;
+			g_timeout = atoi(optarg);
 			break;
 
 		case 'u':
@@ -532,6 +532,8 @@ int main(int argc, char *argv[])
 		g_location = "";
 	if (!g_contact)
 		g_contact = "";
+
+	g_timeout *= 100;
 
 	/* Store the starting time since we need it for MIB updates */
 	if (gettimeofday(&tv_last, NULL) == -1) {


### PR DESCRIPTION
When specified via -t or --timeout, the timeout is interpreted as being
in seconds. In the config file, this wound up being interpreted as
hundredths of seconds, leading to significantly higher resource
consumption than necessary.

Signed-off-by: Matt Merhar <mattmerhar@protonmail.com>