### PR TITLE
linux.c: fix musl build

### DIFF
--- a/linux.c
+++ b/linux.c
@@ -18,7 +18,6 @@
 #include <netpacket/packet.h>
 #include <sys/sysinfo.h>
 #include <sys/socket.h>
-#include <linux/if_link.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/time.h>


### PR DESCRIPTION
Remove include on linux/if_link.h to avoid the following build failure
with musl:

```
In file included from /home/buildroot/autobuild/instance-2/output-1/host/i586-buildroot-linux-musl/sysroot/usr/include/linux/kernel.h:4,
                 from /home/buildroot/autobuild/instance-2/output-1/host/i586-buildroot-linux-musl/sysroot/usr/include/linux/netlink.h:4,
                 from /home/buildroot/autobuild/instance-2/output-1/host/i586-buildroot-linux-musl/sysroot/usr/include/linux/if_link.h:5,
                 from linux.c:21:
/home/buildroot/autobuild/instance-2/output-1/host/i586-buildroot-linux-musl/sysroot/usr/include/linux/sysinfo.h:7:8: error: redefinition of 'struct sysinfo'
 struct sysinfo {
        ^~~~~~~
In file included from linux.c:19:
/home/buildroot/autobuild/instance-2/output-1/host/i586-buildroot-linux-musl/sysroot/usr/include/sys/sysinfo.h:10:8: note: originally defined here
 struct sysinfo {
        ^~~~~~~
  CC       mini_snmpd-globals.o
```

Fixes:
 - http://autobuild.buildroot.org/results/6903a0f685076b4a2c2824de6158da40e9e712d8

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>